### PR TITLE
Replace PHP_EOL with \r\n

### DIFF
--- a/Processor/MultipartUploadProcessor.php
+++ b/Processor/MultipartUploadProcessor.php
@@ -131,7 +131,7 @@ class MultipartUploadProcessor extends AbstractUploadProcessor
             throw new UploadProcessorException(sprintf('An empty content found'));
         }
 
-        $headerLimitation = strpos($content, PHP_EOL.PHP_EOL) + 1;
+        $headerLimitation = strpos($content, "\r\n\r\n") + 1;
         if ($headerLimitation == -1) {
             throw new UploadProcessorException('Unable to determine headers limit');
         }
@@ -142,7 +142,7 @@ class MultipartUploadProcessor extends AbstractUploadProcessor
         $body = substr($content, $headerLimitation);
         $body = trim($body);
 
-        foreach (explode(PHP_EOL, $headersContent) as $header) {
+        foreach (explode("\r\n", $headersContent) as $header) {
             $parts = explode(':', $header);
             if (count($parts) != 2) {
                 continue;
@@ -170,7 +170,7 @@ class MultipartUploadProcessor extends AbstractUploadProcessor
     {
         $contentHandler = $this->getRequestContentHandler($request);
 
-        $delimiter = '--'.$boundary.PHP_EOL;
+        $delimiter = '--'.$boundary."\r\n";
         $endDelimiter = '--'.$boundary.'--';
         $boundaryCount = 0;
         $content = '';
@@ -192,7 +192,7 @@ class MultipartUploadProcessor extends AbstractUploadProcessor
                 $boundaryCount++;
             } elseif ($line == $delimiter) {
                 break;
-            } elseif ($line == $endDelimiter || $line == $endDelimiter.PHP_EOL) {
+            } elseif ($line == $endDelimiter || $line == $endDelimiter."\r\n") {
                 break;
             }
 

--- a/Request/RequestContentHandler.php
+++ b/Request/RequestContentHandler.php
@@ -48,17 +48,17 @@ class RequestContentHandler implements RequestContentHandlerInterface
             return $line;
         }
 
-        $next = strpos($content, PHP_EOL, $this->cursor);
+        $next = strpos($content, "\r\n", $this->cursor);
         $eof = $next < 0 || $next === false;
 
         if ($eof) {
             $line = substr($content, $this->cursor);
         } else {
-            $length = $next - $this->cursor + strlen(PHP_EOL);
+            $length = $next - $this->cursor + strlen("\r\n");
             $line = substr($content, $this->cursor, $length);
         }
 
-        $this->cursor = $eof ? -1 : $next + strlen(PHP_EOL);
+        $this->cursor = $eof ? -1 : $next + strlen("\r\n");
 
         return $line;
     }

--- a/Tests/Processor/MultipartUploadProcessorTest.php
+++ b/Tests/Processor/MultipartUploadProcessorTest.php
@@ -76,8 +76,8 @@ class MultipartUploadProcessorTest extends AbstractProcessorTestCase
 
     protected function createMultipartContent($boundary, $jsonData, $binaryContent)
     {
-        $content = '--'.$boundary.PHP_EOL.'Content-Type: application/json; charset=UTF-8'.PHP_EOL.PHP_EOL.$jsonData.PHP_EOL.PHP_EOL;
-        $content .= '--'.$boundary.PHP_EOL.'Content-Type: image/gif'.PHP_EOL.PHP_EOL.$binaryContent.PHP_EOL.PHP_EOL;
+        $content = '--'.$boundary."\r\n".'Content-Type: application/json; charset=UTF-8'."\r\n\r\n".$jsonData."\r\n\r\n";
+        $content .= '--'.$boundary."\r\n".'Content-Type: image/gif'."\r\n\r\n".$binaryContent."\r\n\r\n";
         $content .= '--'.$boundary.'--';
 
         return $content;

--- a/Tests/Upload/MultipartUploadTest.php
+++ b/Tests/Upload/MultipartUploadTest.php
@@ -9,7 +9,7 @@ class MultipartUploadTest extends AbstractUploadTestCase
         $queryParameters = array('name' => 'test');
 
         $boundary = uniqid();
-        $content = '--'.$boundary.PHP_EOL.'Content-Type: application/json; charset=UTF-8'.PHP_EOL.PHP_EOL.json_encode($queryParameters).PHP_EOL.PHP_EOL;
+        $content = '--'.$boundary."\r\n".'Content-Type: application/json; charset=UTF-8'."\r\n\r\n".json_encode($queryParameters)."\r\n\r\n";
         $content .= '--'.$boundary.'--';
 
         $client->request('POST', '/upload?uploadType=multipart', array(), array(), array(
@@ -26,8 +26,8 @@ class MultipartUploadTest extends AbstractUploadTestCase
 
         $boundary = uniqid();
         $image = $this->getResource($client, 'apple.gif');
-        $content = '--'.$boundary.PHP_EOL.'Content-Type: image/gif'.PHP_EOL.PHP_EOL.$image.PHP_EOL.PHP_EOL;
-        $content .= '--'.$boundary.PHP_EOL.'Content-Type: application/json; charset=UTF-8'.PHP_EOL.PHP_EOL.json_encode($queryParameters).PHP_EOL.PHP_EOL;
+        $content = '--'.$boundary."\r\n".'Content-Type: image/gif'."\r\n\r\n".$image."\r\n\r\n";
+        $content .= '--'.$boundary."\r\n".'Content-Type: application/json; charset=UTF-8'."\r\n\r\n".json_encode($queryParameters)."\r\n\r\n";
         $content .= '--'.$boundary.'--';
 
         $client->request('POST', '/upload?uploadType=multipart', array(), array(), array(), $content);
@@ -41,8 +41,8 @@ class MultipartUploadTest extends AbstractUploadTestCase
 
         $boundary = uniqid();
         $image = $this->getResource($client, 'apple.gif');
-        $content = '--'.$boundary.PHP_EOL.'Content-Type: image/gif'.PHP_EOL.PHP_EOL.$image.PHP_EOL.PHP_EOL;
-        $content .= '--'.$boundary.PHP_EOL.'Content-Type: application/json; charset=UTF-8'.PHP_EOL.PHP_EOL.json_encode($queryParameters).PHP_EOL.PHP_EOL;
+        $content = '--'.$boundary."\r\n".'Content-Type: image/gif'."\r\n\r\n".$image."\r\n\r\n";
+        $content .= '--'.$boundary."\r\n".'Content-Type: application/json; charset=UTF-8'."\r\n\r\n".json_encode($queryParameters)."\r\n\r\n";
         $content .= '--'.$boundary.'--';
 
         $client->request('POST', '/upload?uploadType=multipart', array(), array(), array(
@@ -59,8 +59,8 @@ class MultipartUploadTest extends AbstractUploadTestCase
 
         $boundary = uniqid();
         $image = $this->getResource($client, 'apple.gif');
-        $content = '--'.$boundary.PHP_EOL.'Content-Type: image/gif'.PHP_EOL.PHP_EOL.$image.PHP_EOL.PHP_EOL;
-        $content .= '--'.$boundary.PHP_EOL.'Content-Type: application/json; charset=UTF-8'.PHP_EOL.PHP_EOL.json_encode($queryParameters).PHP_EOL.PHP_EOL;
+        $content = '--'.$boundary."\r\n".'Content-Type: image/gif'."\r\n\r\n".$image."\r\n\r\n";
+        $content .= '--'.$boundary."\r\n".'Content-Type: application/json; charset=UTF-8'."\r\n\r\n".json_encode($queryParameters)."\r\n\r\n";
         $content .= '--'.$boundary.'--';
 
         $client->request('POST', '/upload?uploadType=multipart', array(), array(), array(
@@ -77,8 +77,8 @@ class MultipartUploadTest extends AbstractUploadTestCase
 
         $boundary = uniqid();
         $image = $this->getResource($client, 'apple.gif');
-        $content = '--'.$boundary.PHP_EOL.'Content-Type: application/json; charset=UTF-8'.PHP_EOL.PHP_EOL.json_encode($queryParameters).PHP_EOL.PHP_EOL;
-        $content .= '--'.$boundary.PHP_EOL.'Content-Type: image/gif'.PHP_EOL.PHP_EOL.$image.PHP_EOL.PHP_EOL;
+        $content = '--'.$boundary."\r\n".'Content-Type: application/json; charset=UTF-8'."\r\n\r\n".json_encode($queryParameters)."\r\n\r\n";
+        $content .= '--'.$boundary."\r\n".'Content-Type: image/gif'."\r\n\r\n".$image."\r\n\r\n";
         $content .= '--'.$boundary.'--';
 
         $client->request('POST', '/upload?uploadType=multipart', array(), array(), array(


### PR DESCRIPTION
On many systems `PHP_EOL` is just "\n" that conflicts with the MIME/HTTP specs 