### PR TITLE
Fixed form child counting

### DIFF
--- a/Processor/AbstractUploadProcessor.php
+++ b/Processor/AbstractUploadProcessor.php
@@ -101,7 +101,7 @@ abstract class AbstractUploadProcessor implements ProcessorInterface
     {
         $keys = array();
         foreach ($form->all() as $child) {
-            $keys[$child->getName()] = count($child->all() > 0) ? $this->getFormKeys($child) : null;
+            $keys[$child->getName()] = count($child->all()) > 0 ? $this->getFormKeys($child) : null;
         }
 
         return $keys;


### PR DESCRIPTION
Fixed warning: count(): Parameter must be an array or an object that implements Countable

This change is crucial in case to work with php >= 7.2